### PR TITLE
chore: Add unstable and dev features to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,7 @@ serde_json = "1.0.2"
 [dev-dependencies]
 env_logger = "0.4.3"
 tempdir = "0.3.5"
+
+[features]
+unstable = []
+dev = []


### PR DESCRIPTION
This will make travis-cargo work on nightly versions